### PR TITLE
Update manifest.json to make background scripts cross compatible.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
   ],
 
   "background": {
+    "scripts": ["src/background.js"],
     "service_worker": "src/background.js",
     "type": "module"
   },


### PR DESCRIPTION
Firefox doesn't like `background.service_worker`, but prefers `background.scripts`. It doesn't mind both being there, and other browsers don't seem to mind the addition of background.scripts.